### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Add one of the relationships defined by Enterprise MTI between the container and
       has_one_superclass :shoe
     end
 
-Currently, only `has_one_superclass` (i.e., `has_one`) is defined.  Using `has_one_superclass` effectively means that the container model is in a one-to-one relationship with the childen of the superclass model.
+Currently, only `has_one_superclass` (i.e., `has_one`) is defined.  Using `has_one_superclass` effectively means that the container model is in a one-to-one relationship with the children of the superclass model.
 
 If your superclass is contained within a module, use the `module:` option:
 


### PR DESCRIPTION
@earksiinni, I've corrected a typographical error in the documentation of the [enterprise_mti](https://github.com/earksiinni/enterprise_mti) project. Specifically, I've changed childen to children. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
